### PR TITLE
Changed profile API, remove

### DIFF
--- a/backend/accounts/urls/profile_urls.py
+++ b/backend/accounts/urls/profile_urls.py
@@ -3,7 +3,7 @@ from ..views.profile_views import own_delete_profile, own_update_profile, get_al
 
 urlpatterns = [
     # Profile endpoints
-    path('update_profile/<str:user_id>/', own_update_profile, name='own_update_profile'),
-    path('delete_profile/<str:user_id>/', own_delete_profile, name='own_delete_profile'),
+    path('profile/update/', own_update_profile, name='own_update_profile'),
+    path('profile/delete/', own_delete_profile, name='own_delete_profile'),
     path('profiles/', get_all_users, name="get_all_users"),   
 ]


### PR DESCRIPTION
1. Profile delete and update no longer use path parameteres, instead, the token is expected to be passed in as an "Authorization" bearer.

Q.A. If have existing test account, attempt to update and then delete.  Response should provide success message and other details.